### PR TITLE
Compute base_url as relative path

### DIFF
--- a/voici/addon.py
+++ b/voici/addon.py
@@ -114,8 +114,7 @@ class VoiciAddon(BaseAddon):
         # Convert Notebooks content into static dashboards
         tree_exporter = VoiciTreeExporter(
             jinja2_env=self.jinja2_env,
-            voici_configuration=self.voici_configuration,
-            base_url="/",  # TODO We should grab the correct base_url from the manager?
+            voici_configuration=self.voici_configuration
         )
 
         for file_path, generate_file in tree_exporter.generate_contents(

--- a/voici/exporter.py
+++ b/voici/exporter.py
@@ -24,7 +24,6 @@ from voila.paths import collect_template_paths
 
 class VoiciExporter(VoilaExporter):
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault("base_url", "/voici/")
         kwargs.setdefault("contents_manager", LargeFileManager())
 
         super().__init__(*args, **kwargs)
@@ -64,7 +63,6 @@ class VoiciExporter(VoilaExporter):
             nb, resources, **kwargs
         )
 
-        resources["base_url"] = self.base_url
         resources.setdefault("raw_mimetypes", self.raw_mimetypes)
         resources["global_content_filter"] = {
             "include_code": not self.exclude_code_cell,
@@ -97,6 +95,7 @@ class VoiciExporter(VoilaExporter):
             resources=resources,
             **extra_context,
             static_url=self.static_url,
+            base_url=self.base_url,
             page_config=self.update_page_config(nb, self.page_config),
         ):
             html.append(html_snippet)

--- a/voici/tree_exporter.py
+++ b/voici/tree_exporter.py
@@ -48,13 +48,13 @@ def patch_page_config(page_config: Dict, relative_path: Path):
     # Grabbing from the jupyterlite static folders
     page_config[
         "settingsUrl"
-    ] = f"../../../{'../' * len(relative_path.parts)}build/schemas"
+    ] = f"../../{'../' * len(relative_path.parts)}build/schemas"
     page_config[
         "themesUrl"
     ] = f"../../../{'../' * len(relative_path.parts)}build/themes"
     page_config[
         "fullLabextensionsUrl"
-    ] = f"../../../{'../' * len(relative_path.parts)}extensions"
+    ] = f"../../{'../' * len(relative_path.parts)}extensions"
 
     return page_config
 
@@ -64,12 +64,10 @@ class VoiciTreeExporter(HTMLExporter):
         self,
         jinja2_env: jinja2.Environment,
         voici_configuration: VoilaConfiguration,
-        base_url: str,
         **kwargs,
     ):
         self.jinja2_env = jinja2_env
         self.voici_configuration = voici_configuration
-        self.base_url = base_url
 
         self.theme = voici_configuration.theme
         self.template_name = voici_configuration.template
@@ -81,13 +79,15 @@ class VoiciTreeExporter(HTMLExporter):
     def allowed_content(self, content: Dict) -> bool:
         return content["type"] == "notebook" or content["type"] == "directory"
 
-    def generate_breadcrumbs(self, path: Path) -> List:
-        breadcrumbs = [(url_path_join(self.base_url, "voila/tree"), "")]
+    def generate_breadcrumbs(self, path: Path, depth: int) -> List:
+        root = "../" * depth
+        breadcrumbs = [(url_path_join(root, "voila/tree"), "")]
         parts = path.parts
+
         for i in range(len(parts)):
             if parts[i]:
                 link = url_path_join(
-                    self.base_url,
+                    root,
                     "voila/tree",
                     url_escape(url_path_join(*parts[: i + 1])),
                 )
@@ -118,7 +118,7 @@ class VoiciTreeExporter(HTMLExporter):
                     page_title=page_title,
                     breadcrumbs=breadcrumbs,
                     page_config=page_config,
-                    base_url=self.base_url,
+                    base_url="../../" + "../" * len(relative_path.parts),
                     **self.resources,
                 )
             )
@@ -134,7 +134,7 @@ class VoiciTreeExporter(HTMLExporter):
             voici_exporter = VoiciExporter(
                 voici_config=self.voici_configuration,
                 page_config=page_config,
-                base_url=self.base_url,
+                base_url="../../" + "../" * len(relative_path.parts),
             )
 
             return StringIO(voici_exporter.from_filename(notebook_path)[0])
@@ -149,7 +149,7 @@ class VoiciTreeExporter(HTMLExporter):
             breadcrumbs = []
         else:
             relative_path = path.relative_to(relative_to)
-            breadcrumbs = self.generate_breadcrumbs(relative_path)
+            breadcrumbs = self.generate_breadcrumbs(relative_path, len(relative_path.parts))
 
         template = self.jinja2_env.get_template("tree.html")
 


### PR DESCRIPTION
## References

When served from an higher directory than the jupyterlite output, the tree template would generate broken links to `/voila/render/my-notebook.ipynb`. This PR fixes it by computing the `base_url` relatively to the current path.