### PR TITLE
Depend on `jupyterlite-core`

### DIFF
--- a/demo/jupyter-lite.json
+++ b/demo/jupyter-lite.json
@@ -2,8 +2,7 @@
   "jupyter-lite-schema-version": 0,
   "jupyter-config-data": {
     "disabledExtensions": [
-      "@jupyterlite/javascript-kernel-extension",
-      "@jupyterlite/pyolite-kernel-extension"
+      "@jupyterlite/javascript-kernel-extension"
     ]
   }
 }

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - pip:
     - voila>=0.5.0a2,<0.6.0
     - voila-material>=0.4.3
-    - jupyterlite>=0.1.0b18,<0.2.0
+    - jupyterlite-core[lab] @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl
     - jupyterlite-xeus-python

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - pip:
     - voila>=0.5.0a2,<0.6.0
     - voila-material>=0.4.3
-    - jupyterlite-core[lab]
+    - jupyterlite-core[lab]>=0.1.0a1,<0.2.0
     - jupyterlite-xeus-python

--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
     - voila>=0.5.0a2,<0.6.0
     - voila-material>=0.4.3
     - jupyterlite-core[lab]>=0.1.0a1,<0.2.0
-    - jupyterlite-xeus-python
+    #- jupyterlite-xeus-python

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - pip:
     - voila>=0.5.0a2,<0.6.0
     - voila-material>=0.4.3
-    - jupyterlite-core[lab]>=0.1.0a1,<0.2.0
-    #- jupyterlite-xeus-python
+    - jupyterlite-core[lab]>=0.1.0b19,<0.2.0
+    - jupyterlite-xeus-python >= 0.7.0

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - pip:
     - voila>=0.5.0a2,<0.6.0
     - voila-material>=0.4.3
-    - jupyterlite-core[lab] @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl
+    - jupyterlite-core[lab]
     - jupyterlite-xeus-python

--- a/packages/voici/package.json
+++ b/packages/voici/package.json
@@ -37,7 +37,6 @@
     "@jupyterlite/iframe-extension": "^0.1.0-beta.18",
     "@jupyterlite/javascript-kernel-extension": "^0.1.0-beta.18",
     "@jupyterlite/kernel": "^0.1.0-beta.18",
-    "@jupyterlite/pyolite-kernel-extension": "^0.1.0-beta.18",
     "@jupyterlite/server": "^0.1.0-beta.18",
     "@jupyterlite/server-extension": "^0.1.0-beta.18",
     "@lumino/algorithm": "^1.6.2",

--- a/packages/voici/src/index.ts
+++ b/packages/voici/src/index.ts
@@ -20,7 +20,6 @@ import { loadComponent, createModule, activePlugins } from './utils';
 
 const serverExtensions = [
   import('@jupyterlite/javascript-kernel-extension'),
-  import('@jupyterlite/pyolite-kernel-extension'),
   import('@jupyterlite/server-extension')
 ];
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,9 @@ classifiers = [
 ]
 dependencies = [
     "voila>=0.5.0a2,<0.6.0",
-    "jupyterlite>=0.1.0b18,<0.2.0",
+    # TODO: use the following when jupyterlite-core is released
+    # "jupyterlite-core>=0.1.0b18,<0.2.0",
+    "jupyterlite-core @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl"
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "voila>=0.5.0a2,<0.6.0",
-    # TODO: use the following when jupyterlite-core is released
-    # "jupyterlite-core>=0.1.0b18,<0.2.0",
-    "jupyterlite-core>=0.1.0a1,<0.2.0"
+    "jupyterlite-core>=0.1.0b19,<0.2.0",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,6 @@ dynamic = [
     "version",
 ]
 
-[tool.hatch.metadata]
-allow-direct-references = true
-
 [project.license]
 file = "LICENSE"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ dynamic = [
     "version",
 ]
 
+[tool.hatch.metadata]
+allow-direct-references = true
+
 [project.license]
 file = "LICENSE"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "voila>=0.5.0a2,<0.6.0",
     # TODO: use the following when jupyterlite-core is released
     # "jupyterlite-core>=0.1.0b18,<0.2.0",
-    "jupyterlite-core @ https://jupyterlite--994.org.readthedocs.build/en/994/_static/jupyterlite_core-0.1.0b18-py3-none-any.whl"
+    "jupyterlite-core>=0.1.0a1,<0.2.0"
 ]
 dynamic = [
     "version",

--- a/voici/addon.py
+++ b/voici/addon.py
@@ -15,8 +15,8 @@ from jupyter_server.config_manager import recursive_update
 from voila.configuration import VoilaConfiguration
 from voila.paths import ROOT, collect_static_paths, collect_template_paths
 
-from jupyterlite.addons.base import BaseAddon
-from jupyterlite.constants import (
+from jupyterlite_core.addons.base import BaseAddon
+from jupyterlite_core.constants import (
     JSON_FMT,
     JUPYTER_CONFIG_DATA,
     JUPYTERLITE_JSON,

--- a/voici/app.py
+++ b/voici/app.py
@@ -1,7 +1,7 @@
 from traitlets import default
 
-from jupyterlite.addons import merge_addon_aliases
-from jupyterlite.app import (
+from jupyterlite_core.addons import merge_addon_aliases
+from jupyterlite_core.app import (
     ManagedApp,
     LiteListApp,
     LiteStatusApp,

--- a/voici/app.py
+++ b/voici/app.py
@@ -10,7 +10,6 @@ from jupyterlite_core.app import (
     LiteCheckApp,
     LiteServeApp,
     LiteArchiveApp,
-    PipliteApp,
     LiteApp,
     lite_aliases,
 )
@@ -102,7 +101,6 @@ class VoiciApp(LiteApp):
             check=VoiciCheckApp,
             serve=VoiciServeApp,
             archive=VoiciArchiveApp,
-            pip=PipliteApp,
         ).items()
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,26 +2161,6 @@
     localforage "^1.9.0"
     localforage-memoryStorageDriver "^0.9.2"
 
-"@jupyterlite/pyolite-kernel-extension@^0.1.0-beta.18":
-  version "0.1.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@jupyterlite/pyolite-kernel-extension/-/pyolite-kernel-extension-0.1.0-beta.18.tgz#8fd01fbcc5220fb38a4d2fe3c576a9a9525f80e8"
-  integrity sha512-KqNLE1vUPRoVYXdZL0bKPPvn/5sH7dSnY69XRebVbc09PeopjQoD5IMX4bsPZNjCPqpbYNQgtbMTo/FV/l2DqA==
-  dependencies:
-    "@jupyterlab/coreutils" "~5.5.2"
-    "@jupyterlite/contents" "^0.1.0-beta.18"
-    "@jupyterlite/kernel" "^0.1.0-beta.18"
-    "@jupyterlite/pyolite-kernel" "^0.1.0-beta.18"
-    "@jupyterlite/server" "^0.1.0-beta.18"
-
-"@jupyterlite/pyolite-kernel@^0.1.0-beta.18":
-  version "0.1.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@jupyterlite/pyolite-kernel/-/pyolite-kernel-0.1.0-beta.18.tgz#84295e5f05e15b507967acbcc4307f27e288ecc3"
-  integrity sha512-CsUugrlRoD+naCbOYEuhLecL9YgwH6r5TDeVfBHtlBzzP2MR+KPnwHSXbx7WiDVwzRVcG0pFrzGvRs0CQ0Rvrw==
-  dependencies:
-    "@jupyterlite/contents" "^0.1.0-beta.18"
-    "@jupyterlite/kernel" "^0.1.0-beta.18"
-    comlink "^4.3.1"
-
 "@jupyterlite/server-extension@^0.1.0-beta.18":
   version "0.1.0-beta.18"
   resolved "https://registry.yarnpkg.com/@jupyterlite/server-extension/-/server-extension-0.1.0-beta.18.tgz#aa96cc775929425a70f59e3142a750f4c8dbd556"


### PR DESCRIPTION
<!--
Thanks for contributing to Voici!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Similar to https://github.com/jupyterlite/xeus-python-kernel/pull/114

The core functionality of the `jupyterlite` package is being extracted to a new `jupyterlite-core` package in https://github.com/jupyterlite/jupyterlite/pull/994.

This will allow site deployers to make slimmer deployments without having to bring the Pyodide kernel as well.

## Code changes

- [x] Try depending on `jupyterlite-core` built from https://github.com/jupyterlite/jupyterlite/pull/994
- [x] Update to the real `jupyterlite-core` dependency when a release is available (likely after https://github.com/jupyterlite/jupyterlite/pull/994 is merged)
- [x] Update the docs environment
- [x] Drop dependency on `@jupyterlite/pyolite-kernel-extension`

## User-facing changes


## Backwards-incompatible changes

Should be none