### PR TITLE
Expose the widget manager promise from the `VoiciApp`

### DIFF
--- a/packages/voici/src/app.ts
+++ b/packages/voici/src/app.ts
@@ -64,8 +64,8 @@ export class VoiciApp extends JupyterFrontEnd<IShell> {
   /**
    * A promise that resolves when the Voici Widget Manager is created
    */
-  get managerPromise(): PromiseDelegate<VoiciWidgetManager> {
-    return this._managerPromise;
+  get widgetManagerPromise(): PromiseDelegate<VoiciWidgetManager> {
+    return this._widgetManagerPromise;
   }
 
   /**
@@ -208,7 +208,7 @@ export class VoiciApp extends JupyterFrontEnd<IShell> {
 
         // Create Voila widget manager
         const widgetManager = new VoiciWidgetManager(kernel, rendermime);
-        this._managerPromise.resolve(widgetManager);
+        this._widgetManagerPromise.resolve(widgetManager);
         if (!connection.kernel) {
           return;
         }
@@ -238,7 +238,7 @@ export class VoiciApp extends JupyterFrontEnd<IShell> {
 
   private _serviceManager?: ServiceManager;
   private _kernelspecs?: IKernelSpecs;
-  private _managerPromise = new PromiseDelegate<VoiciWidgetManager>();
+  private _widgetManagerPromise = new PromiseDelegate<VoiciWidgetManager>();
 }
 
 /**

--- a/packages/voici/src/app.ts
+++ b/packages/voici/src/app.ts
@@ -17,8 +17,8 @@ import { IShell, VoilaShell } from '@voila-dashboards/voila';
 import { VoiciWidgetManager } from './manager';
 import { IKernelConnection } from '@jupyterlab/services/lib/kernel/kernel';
 import { IKernelSpecs } from '@jupyterlite/kernel';
+import { PromiseDelegate } from '@lumino/coreutils';
 import { Widget } from '@lumino/widgets';
-import { managerPromise } from './plugins';
 
 const PACKAGE = require('../package.json');
 
@@ -60,6 +60,13 @@ export class VoiciApp extends JupyterFrontEnd<IShell> {
    * The version of the application.
    */
   readonly version = PACKAGE['version'];
+
+  /**
+   * A promise that resolves when the Voici Widget Manager is created
+   */
+  get managerPromise(): PromiseDelegate<VoiciWidgetManager> {
+    return this._managerPromise;
+  }
 
   /**
    * The JupyterLab application paths dictionary.
@@ -201,7 +208,7 @@ export class VoiciApp extends JupyterFrontEnd<IShell> {
 
         // Create Voila widget manager
         const widgetManager = new VoiciWidgetManager(kernel, rendermime);
-        managerPromise.resolve(widgetManager);
+        this._managerPromise.resolve(widgetManager);
         if (!connection.kernel) {
           return;
         }
@@ -231,6 +238,7 @@ export class VoiciApp extends JupyterFrontEnd<IShell> {
 
   private _serviceManager?: ServiceManager;
   private _kernelspecs?: IKernelSpecs;
+  private _managerPromise = new PromiseDelegate<VoiciWidgetManager>();
 }
 
 /**

--- a/packages/voici/src/plugins.ts
+++ b/packages/voici/src/plugins.ts
@@ -29,7 +29,7 @@ const widgetManager = {
         'The Voici Widget Manager plugin must be activated in a VoilaApp'
       );
     }
-    const managerPromise = app.managerPromise;
+    const managerPromise = app.widgetManagerPromise;
     return {
       registerWidget: async (data: any) => {
         const manager = await managerPromise.promise;

--- a/packages/voici/src/plugins.ts
+++ b/packages/voici/src/plugins.ts
@@ -12,12 +12,9 @@ import {
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
 import { IThemeManager } from '@jupyterlab/apputils';
-import { PromiseDelegate } from '@lumino/coreutils';
 import { translatorPlugin, pathsPlugin } from '@voila-dashboards/voila';
 import { PageConfig } from '@jupyterlab/coreutils';
-import { VoiciWidgetManager } from './manager';
-
-export const managerPromise = new PromiseDelegate<VoiciWidgetManager>();
+import { VoiciApp } from './app';
 
 /**
  * The Voici widgets manager plugin.
@@ -26,7 +23,13 @@ const widgetManager = {
   id: '@voila-dashboards/voici:widget-manager',
   autoStart: true,
   provides: base.IJupyterWidgetRegistry,
-  activate: async (): Promise<any> => {
+  activate: async (app: JupyterFrontEnd): Promise<any> => {
+    if (!(app instanceof VoiciApp)) {
+      throw Error(
+        'The Voici Widget Manager plugin must be activated in a VoilaApp'
+      );
+    }
+    const managerPromise = app.managerPromise;
     return {
       registerWidget: async (data: any) => {
         const manager = await managerPromise.promise;


### PR DESCRIPTION
<!--
Thanks for contributing to Voici!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Currently there seems to be an implicit dependency between the `app` and `plugins` modules. Both are using a `managerPromise` to synchronize, which could lead to issues if the modules are used independently or reused in downstream applications.

## Code changes

This change proposes to remove this entanglement by exposing the widget manager promise from the `VoiciApp`, so it can be consumed from the plugin.

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voici public APIs. -->
