### PR TITLE
Update to `jupyterlite-core>=0.1.0b20`

### DIFF
--- a/demo/jupyter-lite.json
+++ b/demo/jupyter-lite.json
@@ -1,8 +1,0 @@
-{
-  "jupyter-lite-schema-version": 0,
-  "jupyter-config-data": {
-    "disabledExtensions": [
-      "@jupyterlite/javascript-kernel-extension"
-    ]
-  }
-}

--- a/environment.yml
+++ b/environment.yml
@@ -8,5 +8,5 @@ dependencies:
   - pip:
     - voila>=0.5.0a2,<0.6.0
     - voila-material>=0.4.3
-    - jupyterlite-core[lab]>=0.1.0b19,<0.2.0
+    - jupyterlite-core[lab]>=0.1.0b20,<0.2.0
     - jupyterlite-xeus-python >= 0.7.0

--- a/packages/voici/package.json
+++ b/packages/voici/package.json
@@ -35,7 +35,6 @@
     "@jupyterlab/ui-components": "^3.0.0",
     "@jupyterlite/contents": "^0.1.0-beta.18",
     "@jupyterlite/iframe-extension": "^0.1.0-beta.18",
-    "@jupyterlite/javascript-kernel-extension": "^0.1.0-beta.18",
     "@jupyterlite/kernel": "^0.1.0-beta.18",
     "@jupyterlite/server": "^0.1.0-beta.18",
     "@jupyterlite/server-extension": "^0.1.0-beta.18",

--- a/packages/voici/src/index.ts
+++ b/packages/voici/src/index.ts
@@ -18,10 +18,7 @@ import { VoiciApp } from './app';
 import plugins from './plugins';
 import { loadComponent, createModule, activePlugins } from './utils';
 
-const serverExtensions = [
-  import('@jupyterlite/javascript-kernel-extension'),
-  import('@jupyterlite/server-extension')
-];
+const serverExtensions = [import('@jupyterlite/server-extension')];
 
 const disabled = ['@jupyter-widgets/jupyterlab-manager'];
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "voila>=0.5.0a2,<0.6.0",
-    "jupyterlite-core>=0.1.0b19,<0.2.0",
+    "jupyterlite-core>=0.1.0b20,<0.2.0",
 ]
 dynamic = [
     "version",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "hatchling.build"
 name = "voici"
 description = "Voici turns Jupyter notebooks into static web applications"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [
     { name = "Voila Development Team" },
 ]
@@ -25,7 +25,6 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1581,7 +1581,7 @@
     react "^17.0.1"
     y-codemirror "^3.0.1"
 
-"@jupyterlab/coreutils@^5.0.0", "@jupyterlab/coreutils@^5.5.2", "@jupyterlab/coreutils@^5.5.3", "@jupyterlab/coreutils@^5.6.1":
+"@jupyterlab/coreutils@^5.0.0", "@jupyterlab/coreutils@^5.5.3", "@jupyterlab/coreutils@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@jupyterlab/coreutils/-/coreutils-5.6.1.tgz#da6c2fe28298ffcad09f1ec5ad4202bdaf1c07c8"
   integrity sha512-nS4ixC9H53lFzdszOfZfDhlM2hlXfOtQAn6TnA/0Ra/gTBQ+LEbFIWdAp588iKuv8eKX39O/Us53T4oq24A31g==
@@ -2109,25 +2109,6 @@
     "@jupyterlab/rendermime-interfaces" "~3.5.2"
     "@lumino/coreutils" "^1.12.0"
     "@lumino/widgets" "^1.33.0"
-
-"@jupyterlite/javascript-kernel-extension@^0.1.0-beta.18":
-  version "0.1.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@jupyterlite/javascript-kernel-extension/-/javascript-kernel-extension-0.1.0-beta.18.tgz#34b7cb86605126da07c53cc896e11e3b9f389afa"
-  integrity sha512-PfFZrppF2Ku5eJvnUPNYNGJ3eDLatPTpDkU42GaF65xLXHeGPRFZa8agh/jpmqq9MtMzJdpPmOzHNG9gRLanfA==
-  dependencies:
-    "@jupyterlab/coreutils" "~5.5.2"
-    "@jupyterlite/javascript-kernel" "^0.1.0-beta.18"
-    "@jupyterlite/kernel" "^0.1.0-beta.18"
-    "@jupyterlite/server" "^0.1.0-beta.18"
-
-"@jupyterlite/javascript-kernel@^0.1.0-beta.18":
-  version "0.1.0-beta.18"
-  resolved "https://registry.yarnpkg.com/@jupyterlite/javascript-kernel/-/javascript-kernel-0.1.0-beta.18.tgz#f75c738e53ddf4c7d304ced81191e1ec7cb0a986"
-  integrity sha512-FATbSEeXi+Am2dmY4GWltnzHCQXCKM6oMikLmWxJRKIOBqjbFPbmFPe/Rzfb7lXV9tz/3PtgEAkvmXIfG2ny4w==
-  dependencies:
-    "@jupyterlab/coreutils" "^5.5.2"
-    "@jupyterlite/kernel" "^0.1.0-beta.18"
-    comlink "^4.3.1"
 
 "@jupyterlite/kernel@^0.1.0-beta.18":
   version "0.1.0-beta.18"


### PR DESCRIPTION


## References

Update to the latest `jupyterlite-core`: https://github.com/jupyterlite/jupyterlite/releases/tag/v0.1.0b20

Which does not include the JavaScript kernel by default anymore: https://github.com/jupyterlite/jupyterlite/pull/1013


## Code changes

- [x] Update to `jupyterlite-core==0.1.0b20`
- [x] Require Python 3.8


## User-facing changes

The JavaScript kernel should not be available by default.

## Backwards-incompatible changes

The JavaScript kernel should not be available by default.
