### PR TITLE
Remove the `reset_stable.sh` script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,7 +112,6 @@ before-build-npm = [
 before-build-python = [
     "yarn clean",
 ]
-after-draft-release = "bash ./scripts/reset-stable.sh"
 
 [tool.jupyter-releaser.options]
 version-cmd = "python scripts/bump-version.py --force"

--- a/scripts/reset-stable.sh
+++ b/scripts/reset-stable.sh
@@ -1,9 +1,0 @@
-set -eux
-
-git checkout stable || git checkout -b stable
-git reset --hard origin/main
-
-# Update the stable branch to point the latest release
-if [[ ${RH_DRY_RUN:=true} != 'true' ]]; then
-    git push origin stable -f
-fi


### PR DESCRIPTION
<!--
Thanks for contributing to Voici!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Minor cleanup to remove the `reset_stable.sh` script.

This seems to be coming from the voila repo, but is not needed or used here.

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Cleanup repo.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voici public APIs. -->

None