### PR TITLE
Use `ruff` instead of `flake8`, run `black`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length=200
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,8 @@ jobs:
         extra-specs: |
           python=${{ matrix.python_version }}
 
-    - name: Flake8
-      run: python -m flake8 voici setup.py
+    - name: Lint (Python)
+      run: python -m ruff check voici setup.py
 
     - name: Install voici
       run: pip install .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,9 @@ jobs:
           python=${{ matrix.python_version }}
 
     - name: Lint (Python)
-      run: python -m ruff check voici setup.py
+      run: |
+        python -m ruff check .
+        python -m black --check .
 
     - name: Install voici
       run: pip install .

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,8 +2,11 @@ import os
 
 # Add dev disclaimer.
 _release = {}
-exec(compile(open('../../voici/_version.py').read(), '../../voici/_version.py', 'exec'), _release)
-if _release['version_info'][-1] == 'dev':
+exec(
+    compile(open("../../voici/_version.py").read(), "../../voici/_version.py", "exec"),
+    _release,
+)
+if _release["version_info"][-1] == "dev":
     rst_prolog = """
     .. note::
 
@@ -12,12 +15,10 @@ if _release['version_info'][-1] == 'dev':
 
     """
 
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get("READTHEDOCS", None) == "True"
 
 html_theme = "pydata_sphinx_theme"
-html_theme_options = dict(
-    github_url='https://github.com/voila-dashboards/voici'
-)
+html_theme_options = dict(github_url="https://github.com/voila-dashboards/voici")
 
 
 def setup(app):
@@ -25,27 +26,27 @@ def setup(app):
 
 
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-    'sphinx.ext.napoleon',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
+    "sphinx.ext.napoleon",
 ]
 
-html_static_path = ['_static']
-source_suffix = '.rst'
-master_doc = 'index'
-project = 'voici'
-copyright = u'2020, The Voilà Development Team'
-author = u'The Voilà Development Team'
-version = '.'.join(map(str, _release['version_info'][:2]))
-release = _release['__version__']
+html_static_path = ["_static"]
+source_suffix = ".rst"
+master_doc = "index"
+project = "voici"
+copyright = "2020, The Voilà Development Team"
+author = "The Voilà Development Team"
+version = ".".join(map(str, _release["version_info"][:2]))
+release = _release["__version__"]
 language = None
 
-html_logo = 'voila-logo.svg'
+html_logo = "voila-logo.svg"
 
 exclude_patterns = []
-highlight_language = 'python'
-pygments_style = 'sphinx'
+highlight_language = "python"
+pygments_style = "sphinx"
 todo_include_todos = False
-htmlhelp_basename = 'voicidoc'
+htmlhelp_basename = "voicidoc"
 
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {"https://docs.python.org/": None}

--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - pip
-  - ruff==0.0.258
+  - black
   - yarn=1
   - pip:
+    - ruff==0.0.258
     - voila>=0.5.0a3,<0.6.0
     - voila-material>=0.4.3
     - jupyterlite-core[lab]>=0.1.0b20,<0.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,8 @@ channels:
   - conda-forge
 dependencies:
   - pip
+  - ruff==0.0.258
   - yarn=1
-  - flake8
   - pip:
     - voila>=0.5.0a3,<0.6.0
     - voila-material>=0.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ file = "LICENSE"
 [project.optional-dependencies]
 dev = [
     "black",
-    "ruff",
+    "ruff==0.0.258",
     "hatch",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ file = "LICENSE"
 [project.optional-dependencies]
 dev = [
     "black",
+    "ruff",
     "hatch",
-    "jupyter_releaser",
 ]
 
 [project.scripts]
@@ -119,3 +119,7 @@ version-cmd = "python scripts/bump-version.py"
 
 [tool.check-wheel-contents]
 ignore = ["W002"]
+
+[tool.ruff]
+target-version = "py38"
+line-length = 100

--- a/voici/addon.py
+++ b/voici/addon.py
@@ -81,7 +81,8 @@ class VoiciAddon(BaseAddon):
         self.jinja2_env.install_gettext_translations(nbui, newstyle=False)
 
     def post_build(self, manager):
-        """copies the Voici application files to the JupyterLite output and generate static dashboards."""
+        """Copies the Voici application files to the JupyterLite output
+        and generate static dashboards."""
 
         # Do nothing if Voici is disabled
         if not self.manager.apps or (
@@ -113,8 +114,7 @@ class VoiciAddon(BaseAddon):
 
         # Convert Notebooks content into static dashboards
         tree_exporter = VoiciTreeExporter(
-            jinja2_env=self.jinja2_env,
-            voici_configuration=self.voici_configuration
+            jinja2_env=self.jinja2_env, voici_configuration=self.voici_configuration
         )
 
         for file_path, generate_file in tree_exporter.generate_contents(

--- a/voici/app.py
+++ b/voici/app.py
@@ -17,10 +17,10 @@ from jupyterlite_core.app import (
 
 voici_aliases = dict(
     **lite_aliases,
-    show_tracebacks='VoilaConfiguration.show_tracebacks',
-    strip_sources='VoilaConfiguration.strip_sources',
-    template='VoilaConfiguration.template',
-    theme='VoilaConfiguration.theme',
+    show_tracebacks="VoilaConfiguration.show_tracebacks",
+    strip_sources="VoilaConfiguration.strip_sources",
+    template="VoilaConfiguration.template",
+    theme="VoilaConfiguration.theme",
 )
 
 

--- a/voici/tree_exporter.py
+++ b/voici/tree_exporter.py
@@ -147,7 +147,8 @@ class VoiciTreeExporter(HTMLExporter):
         self, path: Path, lite_files_output: Path, relative_to=None
     ) -> Tuple[Dict, List[str]]:
         """Generate the Tree content.
-           This is a generator method that generates tuples (filepath, filecreation_function)."""
+        This is a generator method that generates tuples (filepath, filecreation_function).
+        """
         if relative_to is None:
             relative_to = path
             relative_path = Path(".")

--- a/voici/tree_exporter.py
+++ b/voici/tree_exporter.py
@@ -115,7 +115,7 @@ class VoiciTreeExporter(HTMLExporter):
 
             return StringIO(
                 template.render(
-                    frontend='voici',
+                    frontend="voici",
                     contents=contents,
                     page_title=page_title,
                     breadcrumbs=breadcrumbs,
@@ -143,15 +143,20 @@ class VoiciTreeExporter(HTMLExporter):
 
         return render_notebook
 
-    def generate_contents(self, path: Path, lite_files_output: Path, relative_to=None) -> Tuple[Dict, List[str]]:
-        """Generate the Tree content. This is a generator method that generates tuples (filepath, filecreation_function)."""
+    def generate_contents(
+        self, path: Path, lite_files_output: Path, relative_to=None
+    ) -> Tuple[Dict, List[str]]:
+        """Generate the Tree content.
+           This is a generator method that generates tuples (filepath, filecreation_function)."""
         if relative_to is None:
             relative_to = path
             relative_path = Path(".")
             breadcrumbs = []
         else:
             relative_path = path.relative_to(relative_to)
-            breadcrumbs = self.generate_breadcrumbs(relative_path, len(relative_path.parts))
+            breadcrumbs = self.generate_breadcrumbs(
+                relative_path, len(relative_path.parts)
+            )
 
         template = self.jinja2_env.get_template("tree.html")
 
@@ -174,7 +179,8 @@ class VoiciTreeExporter(HTMLExporter):
                 yield (
                     Path("render") / file["path"],
                     self.will_render_notebook(
-                        lite_files_output / file["path"].replace(".html", ".ipynb"), relative_path
+                        lite_files_output / file["path"].replace(".html", ".ipynb"),
+                        relative_path,
                     ),
                 )
             elif file["type"] == "directory":


### PR DESCRIPTION
<!--
Thanks for contributing to Voici!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

`ruff` is getting a lot of traction and has been adopted on many Jupyter projects already.

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Remove flake8 config
- [x] Use `ruff`
- [x] Run `black` on the code base
- [x] Add simple CI check to run `ruff` and `black`

A follow-up could be to add `pre-commit` like in Voila: https://github.com/voila-dashboards/voila/pull/1306

## User-facing changes

None

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voici public APIs. -->
