### PR TITLE
Fetch theme name from the body data attribute

### DIFF
--- a/packages/voici/src/plugins.ts
+++ b/packages/voici/src/plugins.ts
@@ -17,6 +17,16 @@ import { PageConfig } from '@jupyterlab/coreutils';
 import { VoiciApp } from './app';
 
 /**
+ * The name for the default JupyterLab light theme
+ */
+const DEFAULT_JUPYTERLAB_LIGHT_THEME = 'JupyterLab Light';
+
+/**
+ * The name for the default JupyterLab dark theme
+ */
+const DEFAULT_JUPYTERLAB_DARK_THEME = 'JupyterLab Dark';
+
+/**
  * The Voici widgets manager plugin.
  */
 const widgetManager = {
@@ -51,20 +61,23 @@ export const themePlugin: JupyterFrontEndPlugin<void> = {
       return;
     }
 
-    const labThemeName = PageConfig.getOption('labThemeName');
-
     const search = window.location.search;
     const urlParams = new URLSearchParams(search);
     const urltheme = urlParams.get('theme');
+
+    // retrieve the name of the theme as it may already be set as a data attribute on the page
+    const labThemeName = PageConfig.getOption('jpThemeName');
+
+    // query string parameter takes precedence over the page config value
     let theme = urltheme ? decodeURIComponent(urltheme) : labThemeName;
 
     // default to the light theme if the theme is not specified (empty)
     theme = theme || 'light';
 
-    if (theme === 'dark') {
+    if (theme === 'dark' || theme === DEFAULT_JUPYTERLAB_DARK_THEME) {
       theme = 'JupyterLab Dark';
     }
-    if (theme === 'light') {
+    if (theme === 'light' || theme === DEFAULT_JUPYTERLAB_LIGHT_THEME) {
       theme = 'JupyterLab Light';
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Voici!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

This should help mitigate https://github.com/voila-dashboards/voici/issues/36.

## Code changes

Read `data-jp-theme-name` which may be available on the page already if set by a template.

## User-facing changes

There might still be a flickering effect, but the `--theme` value should persist.

Below is a screencast of a voici app built with: `voici build --contents notebooks --theme=dark`


https://user-images.githubusercontent.com/591645/231776577-f9c665d7-3c03-4a90-89f1-4fb865c0962c.mp4

![image](https://user-images.githubusercontent.com/591645/231776659-9d6fe043-922a-483b-bca1-4a6ed39a45a5.png)


## Backwards-incompatible changes

None
