### PR TITLE
Update CLI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Note: You will need NodeJS to build the extension package.
 
 ```bash
 # create a new environment
-mamba create -f environment.yml
+mamba env create -f environment.yml
 
 # activate the environment
 mamba activate voici-dev

--- a/voici/addon.py
+++ b/voici/addon.py
@@ -143,9 +143,9 @@ class VoiciAddon(BaseAddon):
 
     def update_index(self, desc: Path):
         """Update the redirect URL"""
-        contents_path = self.manager.contents[0]
-        if contents_path.is_file():
-            file_name = contents_path.stem
+
+        if len(self.manager.contents) == 1 and self.manager.contents[0].is_file():
+            file_name = self.manager.contents[0].stem
             new_url = f"/voici/render/{file_name}.html"
         else:
             new_url = "/voici/tree/index.html"

--- a/voici/addon.py
+++ b/voici/addon.py
@@ -130,6 +130,32 @@ class VoiciAddon(BaseAddon):
                 ],
             )
 
+        # Update index page
+        yield dict(
+            name=f"voici:update_index:{self.manager.output_dir}",
+            actions=[
+                (
+                    self.update_index,
+                    [self.manager.output_dir / "voici"],
+                )
+            ],
+        )
+
+    def update_index(self, desc: Path):
+        """Update the redirect URL"""
+        contents_path = self.manager.contents[0]
+        if contents_path.is_file():
+            file_name = contents_path.stem
+            new_url = f"/voici/render/{file_name}.html"
+        else:
+            new_url = "/voici/tree/index.html"
+        index_file = desc / "index.html"
+        with open(index_file, "r+") as f:
+            content = f.read()
+            new_content = content.replace(r"{{voici_index_url}}", new_url)
+            f.seek(0)
+            f.write(new_content)
+
     def create_dashboard_or_tree(
         self, generate_file: Callable[[Dict], io.StringIO], dest: Path
     ):
@@ -177,7 +203,7 @@ class VoiciAddon(BaseAddon):
         page_config = config.get(JUPYTER_CONFIG_DATA, {})
 
         # Patch appUrl
-        page_config["appUrl"] = "./voici/tree"
+        page_config["appUrl"] = "./voici"
 
         # Path favicon
         page_config["faviconUrl"] = "./voici/favicon.ico"

--- a/voici/static/index.html
+++ b/voici/static/index.html
@@ -4,8 +4,8 @@
     <script>
       (function () {
         window.location.href = window.location.href.replace(
-          /\/voila(\/|\/index.html)?$/,
-          '/voila/tree/index.html'
+          /\/voici(\/|\/index.html)?$/,
+          '{{voici_index_url}}'
         );
       }.call(this));
     </script>


### PR DESCRIPTION

## References
Closes #20 


https://user-images.githubusercontent.com/4451292/232506408-6cca3f03-9420-4a22-951f-1e7bd4a55622.mp4


## User-facing changes
The `voici` command now has the same behavior of the `voila` command
- To build a single notebook
```
voici notebook.ipynb --theme dark ...
```
In this case, the tree view is bypassed and users are immediately redirected to the notebook page.

- To build a directory notebook
```
voici  <path-to-notebook-dir> --theme dark --template= ...
```
The path can be an absolute or relative path. Users are redirected to the tree view on starting voici.

- Users still have access to all others `jupyterlite` commands and options
<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes
N/A
<!-- Describe any backwards-incompatible changes to Voici public APIs. -->
