### PR TITLE
Add missing `react-dom` module to Webpack shared scope

### DIFF
--- a/packages/voici/package.json
+++ b/packages/voici/package.json
@@ -50,7 +50,8 @@
     "@lumino/virtualdom": "^1.11.2",
     "@lumino/widgets": "^1.26.2",
     "@voila-dashboards/voila": "^0.5.0-alpha.3",
-    "react": "^17.0.1"
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.2.2",

--- a/packages/voici/src/index.ts
+++ b/packages/voici/src/index.ts
@@ -8,12 +8,12 @@
  ****************************************************************************/
 import '@jupyterlab/nbconvert-css/style/index.css';
 
+import 'react-dom';
 import { PageConfig, URLExt } from '@jupyterlab/coreutils';
 import { JupyterLiteServer } from '@jupyterlite/server';
 import { IKernelSpecs } from '@jupyterlite/kernel';
 
 import { VoilaShell } from '@voila-dashboards/voila';
-
 import { VoiciApp } from './app';
 import plugins from './plugins';
 import { loadComponent, createModule, activePlugins } from './utils';


### PR DESCRIPTION

## References

Issue found while working with a widget requiring the `react-dom` module.

## Code changes

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voici public APIs. -->
