### PR TITLE
Fix: Proper redirect URL when we have just one Notebook

### DIFF
--- a/voici/addon.py
+++ b/voici/addon.py
@@ -143,9 +143,14 @@ class VoiciAddon(BaseAddon):
 
     def update_index(self, desc: Path):
         """Update the redirect URL"""
+        notebooks = [
+            ntbs
+            for content in self.manager.contents
+            for ntbs in content.glob("**/*.ipynb")
+        ]
 
-        if len(self.manager.contents) == 1 and self.manager.contents[0].is_file():
-            file_name = self.manager.contents[0].stem
+        if len(notebooks) == 1:
+            file_name = notebooks[0].stem
             new_url = f"/voici/render/{file_name}.html"
         else:
             new_url = "/voici/tree/index.html"


### PR DESCRIPTION
## References

I've encountered this in https://github.com/martinRenou/voici-jupytercon-2023 where our content is a directory with just one Notebook with a data file. Then the redirect URL would not automatically be the Notebook.

## Code changes

Actually count the Notebooks in the contents