### PR TITLE
Update publish workflow for trusted publishers

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,20 +1,24 @@
-name: "Step 2: Publish Release"
+name: 'Step 2: Publish Release'
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "The target branch"
+        description: 'The target branch'
         required: false
       release_url:
-        description: "The URL of the draft GitHub release"
+        description: 'The URL of the draft GitHub release'
         required: false
       steps_to_skip:
-        description: "Comma separated list of steps to skip"
+        description: 'Comma separated list of steps to skip'
         required: false
 
 jobs:
   publish_release:
     runs-on: ubuntu-latest
+    permissions:
+      # This is useful if you want to use PyPI trusted publisher
+      # and NPM provenance
+      id-token: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
@@ -23,7 +27,6 @@ jobs:
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
-          target: ${{ github.event.inputs.target }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
@@ -31,23 +34,19 @@ jobs:
       - name: Finalize Release
         id: finalize-release
         env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          PYPI_TOKEN_MAP: ${{ secrets.PYPI_TOKEN_MAP }}
-          TWINE_USERNAME: __token__
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        uses: jupyter-server/jupyter-releaser/.github/actions/finalize-release@v2
+        uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
-          target: ${{ github.event.inputs.target }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 
-      - name: "** Next Step **"
+      - name: '** Next Step **'
         if: ${{ success() }}
         run: |
           echo "Verify the final release"
           echo ${{ steps.finalize-release.outputs.release_url }}
 
-      - name: "** Failure Message **"
+      - name: '** Failure Message **'
         if: ${{ failure() }}
         run: |
           echo "Failed to Publish the Draft Release Url:"

--- a/packages/voici/package.json
+++ b/packages/voici/package.json
@@ -6,6 +6,14 @@
   "license": "BSD-3-Clause",
   "main": "lib/main.js",
   "browserslist": ">0.8%, not ie 11, not op_mini all, not dead",
+  "homepage": "https://github.com/voila-dashboards/voici",
+  "bugs": {
+    "url": "https://github.com/voila-dashboards/voici/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voila-dashboards/voici"
+  },
   "dependencies": {
     "@jupyter-widgets/base": "^6.0.6",
     "@jupyter-widgets/jupyterlab-manager": "^5.0.9",


### PR DESCRIPTION
<!--
Thanks for contributing to Voilà!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Similar to https://github.com/voila-dashboards/voila/pull/1434

Start using trusted publishers for publishing Voila to PyPI.

This will help to not have to deal with 2FA with the bot account: https://blog.pypi.org/posts/2024-01-01-2fa-enforced/

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

- [x] Update `publish-release.yml` to remove the PyPI token and set up `id-token`
- [x] Setup `voici` on PyPI to use trusted publishers

![image](https://github.com/voila-dashboards/voici/assets/591645/fc783c0f-42af-403f-8155-37d3f9041a33)


<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

None

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

None

<!-- Describe any backwards-incompatible changes to Voilà public APIs. -->
