### PR TITLE
Fix docs build

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - conda
 dependencies:
+  - micromamba
   - myst-parser
   - nodejs=18
   - sphinx

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -12,6 +12,5 @@ dependencies:
   - yarn=3
   - pip:
     - sphinxcontrib-video
-    - jupyterlite-xeus --pre
     - ../python/voici-core
     - ../python/voici

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - myst-parser
   - nodejs=18
   - sphinx
+  - pip
   - pydata-sphinx-theme
   - yarn=3
   - pip:

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,6 +11,6 @@ dependencies:
   - yarn=3
   - pip:
     - sphinxcontrib-video
-    - jupyterlite-xeus
+    - jupyterlite-xeus --pre
     - ../python/voici-core
     - ../python/voici

--- a/python/voici/pyproject.toml
+++ b/python/voici/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "voici-core",
-    "jupyterlite-xeus>=0.1.3",
+    "jupyterlite-xeus>=0.2.0a0",
 ]
 dynamic = [
     "version",


### PR DESCRIPTION
<!--
Thanks for contributing to Voici!
Please fill out the following items to submit a pull request.
See the contributing guidelines for more information:
https://github.com/voila-dashboards/voila/blob/main/CONTRIBUTING.md
-->

## References

Troubleshoot the docs build failure as seen in https://github.com/voila-dashboards/voici/pull/119

Related to https://github.com/conda/conda/pull/13962

And the latest changes in `jupyterlite-xeus` that changed the priory of `micromamba` / `mamba` / `conda`: https://github.com/jupyterlite/xeus/pull/88
Released in `0.2.0a0`: https://github.com/jupyterlite/xeus/releases/tag/v0.2.0a0

<!-- Note issue numbers this pull request addresses. -->

<!-- Note any other pull requests that address this issue and how this pull request is different. -->

## Code changes

Update lower bound on `jupyterlite-xeus` in the `voici` package to make the build pass.

<!-- Describe the code changes and how they address the issue. -->

## User-facing changes

Users may not be able to use an older `jupyterlite-xeus`, but it looks like it may be broken anyway?

<!-- Describe any visual or user interaction changes and how they address the issue. -->

<!--
For visual changes, include before and after screenshots here.

You will also need to update the reference screenshots for the Galata visual regression tests,
you can do this automatically by commenting "Please update galata references" in the PR.
-->

## Backwards-incompatible changes

<!-- Describe any backwards-incompatible changes to Voici public APIs. -->
