### PR TITLE
Fix `voici build --help`

### DIFF
--- a/python/voici-core/voici_core/app.py
+++ b/python/voici-core/voici_core/app.py
@@ -16,6 +16,8 @@ from jupyterlite_core.app import (
     lite_aliases,
 )
 from traitlets import default
+from voila.configuration import VoilaConfiguration
+
 from ._version import __version__
 
 voici_aliases = dict(
@@ -29,6 +31,8 @@ voici_aliases = dict(
 
 
 class VoiciAppMixin(ManagedApp):
+    classes = [VoilaConfiguration]
+
     @default('lite_manager')
     def _default_manager(self):
         manager = super()._default_manager()


### PR DESCRIPTION

## References

This should fix https://github.com/voila-dashboards/voici/issues/130

## Code changes

Make `voici build --help` return the help.

## User-facing changes

`voici build --help` should not fail.

## Backwards-incompatible changes

None
